### PR TITLE
Change image base to PyPy 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM pypy:3.6-stretch
 LABEL maintainer="kelwing@auttaja.io"
 WORKDIR /opt/auttaja
 COPY requirements.txt requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pypy:3.6-stretch
+FROM jamiehewland/alpine-pypy:3.6-alpine3.9
 LABEL maintainer="kelwing@auttaja.io"
 WORKDIR /opt/auttaja
 COPY requirements.txt requirements.txt


### PR DESCRIPTION
**IMPORTANT NOTE:** This also requires the entry point in the Auttaja 3.0 Docker image to be set to `ENTRYPOINT ["pypy3", "main.py"]`